### PR TITLE
Update 02-certificate-mgmt helm add linkerd repo

### DIFF
--- a/linkerd-in-production/02-certificate-mgmt/README.md
+++ b/linkerd-in-production/02-certificate-mgmt/README.md
@@ -52,6 +52,7 @@ step certificate create identity.linkerd.cluster.local issuer.crt issuer.key \
 ## Step 1: add the jetstack helm repo 
 
 helm repo add jetstack https://charts.jetstack.io
+helm repo add linkerd https://helm.linkerd.io/stable
 helm repo update
 
 ## Step 2: Install cert-manager
@@ -75,7 +76,7 @@ kubectl apply -f manifests/bootstrap_ca.yaml
 
 ### Take a look at our custom objects
 
-cat bootstrap_ca.yaml
+cat manifests/bootstrap_ca.yaml
 
 ### Inspect the root certificate
 


### PR DESCRIPTION
From workshop run on 2022-10-25, Kubecon day 2

This PR adds the command `helm repo add linkerd https://helm.linkerd.io/stable` to the `02-certificate-mgmt/README.md` steps

Reviewer may consider adding the command `linkerd uninstall -f | kubectl delete -f -` to the beginning of the README.md to ensure user is starting with a fresh install