### PR TITLE
add sleep to allow secret to be created before access

### DIFF
--- a/linkerd-in-production/02-certificate-mgmt/cert-manager.sh
+++ b/linkerd-in-production/02-certificate-mgmt/cert-manager.sh
@@ -174,6 +174,8 @@ bat manifests/cert-manager-identity-issuer.yaml
 # We'll apply those and then look at the resulting Secret.
 kubectl apply -f manifests/cert-manager-identity-issuer.yaml
 
+sleep 3
+
 kubectl describe secret -n linkerd linkerd-identity-issuer
 
 #@wait


### PR DESCRIPTION
If not using the presentation tool, the apply above the sleep can complete quickly enough that the describe below doesn't complete because the control plane hasn't finished the creation yet. A basic sleep can address this by giving the control plane time to finish working things out. 